### PR TITLE
Fix(Issue #9): Improve null handling in issue formatter

### DIFF
--- a/src/formatters/issues.ts
+++ b/src/formatters/issues.ts
@@ -3,7 +3,10 @@ import type { RedmineApiResponse, RedmineIssue } from "../lib/types/index.js";
 /**
  * Escape XML special characters
  */
-function escapeXml(unsafe: string): string {
+function escapeXml(unsafe: string | null | undefined): string {
+  if (unsafe === null || unsafe === undefined) {
+    return '';
+  }
   return unsafe
     .replace(/[&]/g, '&amp;')
     .replace(/[<]/g, '&lt;')
@@ -31,23 +34,30 @@ function formatCustomFields(fields: Array<{ id: number; name: string; value: str
  * Format a single issue
  */
 export function formatIssue(issue: RedmineIssue): string {
-  const safeDescription = issue.description ? escapeXml(issue.description) : '';
+  const safeDescription = escapeXml(issue.description);
 
   return `<issue>
   <id>${issue.id}</id>
   <subject>${escapeXml(issue.subject)}</subject>
-  <project>${escapeXml(issue.project.name)}</project>
-  <status>${escapeXml(issue.status.name)}</status>
-  <priority>${escapeXml(issue.priority.name)}</priority>
-  ${issue.assigned_to ? `<assigned_to>${escapeXml(issue.assigned_to.name)}</assigned_to>` : ''}
-  ${issue.category ? `<category>${escapeXml(issue.category.name)}</category>` : ''}
-  ${issue.fixed_version ? `<version>${escapeXml(issue.fixed_version.name)}</version>` : ''}
+  <project>${escapeXml(issue.project?.name)}</project>
+  <tracker>${escapeXml(issue.tracker?.name)}</tracker>
+  <status>${escapeXml(issue.status?.name)}</status>
+  <priority>${escapeXml(issue.priority?.name)}</priority>
+  ${issue.author ? `<author>${escapeXml(issue.author?.name)}</author>` : ''}
+  ${issue.assigned_to ? `<assigned_to>${escapeXml(issue.assigned_to?.name)}</assigned_to>` : ''}
+  ${issue.category ? `<category>${escapeXml(issue.category?.name)}</category>` : ''}
+  ${issue.fixed_version ? `<version>${escapeXml(issue.fixed_version?.name)}</version>` : ''}
+  ${issue.parent ? `<parent_id>${issue.parent?.id}</parent_id>` : ''}
   ${issue.start_date ? `<start_date>${issue.start_date}</start_date>` : ''}
   ${issue.due_date ? `<due_date>${issue.due_date}</due_date>` : ''}
-  ${issue.estimated_hours ? `<estimated_hours>${issue.estimated_hours}</estimated_hours>` : ''}
-  <progress>${issue.done_ratio}%</progress>
-  ${issue.description ? `<description>${safeDescription}</description>` : ''}
+  ${issue.done_ratio !== undefined ? `<progress>${issue.done_ratio}%</progress>` : ''}
+  ${issue.estimated_hours !== undefined ? `<estimated_hours>${issue.estimated_hours}</estimated_hours>` : ''}
+  ${issue.spent_hours !== undefined ? `<spent_hours>${issue.spent_hours}</spent_hours>` : ''}
+  ${safeDescription ? `<description>${safeDescription}</description>` : ''}
   ${issue.custom_fields?.length ? formatCustomFields(issue.custom_fields) : ''}
+  ${issue.created_on ? `<created_on>${issue.created_on}</created_on>` : ''}
+  ${issue.updated_on ? `<updated_on>${issue.updated_on}</updated_on>` : ''}
+  ${issue.closed_on ? `<closed_on>${issue.closed_on}</closed_on>` : ''}
 </issue>`;
 }
 
@@ -55,14 +65,15 @@ export function formatIssue(issue: RedmineIssue): string {
  * Format list of issues
  */
 export function formatIssues(response: RedmineApiResponse<RedmineIssue>): string {
-  if (!Array.isArray(response.issues) || response.issues.length === 0) {
+  // response や response.issues が null/undefined の場合のチェックを追加
+  if (!response || !response.issues || !Array.isArray(response.issues) || response.issues.length === 0) {
     return '<?xml version="1.0" encoding="UTF-8"?>\n<issues type="array" total_count="0" limit="0" offset="0" />';
   }
 
   const issues = response.issues.map(formatIssue).join('\n');
   
   return `<?xml version="1.0" encoding="UTF-8"?>
-<issues type="array" total_count="${response.total_count}" offset="${response.offset}" limit="${response.limit}">
+<issues type="array" total_count="${response.total_count || 0}" offset="${response.offset || 0}" limit="${response.limit || 0}">
 ${issues}
 </issues>`;
 }


### PR DESCRIPTION
This PR fixes a potential 'Cannot read properties of null (reading \'replace\')' error in the `list_issues` handler when `project_id` is specified. 

Addresses: yonaka15/mcp-server-redmine#9

**Changes:**
- Modified `escapeXml` to gracefully handle `null` or `undefined` input by returning an empty string. This prevents errors if a field expected to be a string is missing.
- Updated `formatIssue` to use optional chaining (`?.`) for all potentially nullable properties (e.g., `issue.project?.name`, `issue.status?.name`). This ensures that if an object in the issue data is `null` or `undefined`, accessing its properties won't cause a runtime error.
- Added more comprehensive null checks in `formatIssues` for the overall API response and its metadata (like `total_count`, `offset`, `limit`) to provide default values if they are missing.
- Expanded `formatIssue` to include more fields from the `RedmineIssue` type, ensuring richer XML output and aligning better with the data model.

These changes should make the issue formatting more robust against variations in the Redmine API response, particularly when `project_id` filtering might alter the structure or completeness of the returned issue data.