### PR TITLE
Fix: Apply positive validation to hours in TimeEntry schema (resolves #7)

### DIFF
--- a/src/lib/types/time_entries/schema.ts
+++ b/src/lib/types/time_entries/schema.ts
@@ -31,7 +31,7 @@ export const RedmineTimeEntrySchema = z.object({
     id: z.number(),
     name: z.string(),
   }),
-  hours: z.number(),
+  hours: z.number().positive(),
   comments: z.string().optional(),
   spent_on: z.string(),
   created_on: z.string(),


### PR DESCRIPTION
This PR addresses issue #7 (MCPクライアントからの接続時に「Incorrect type. Expected "number". (at /properties/hours/exclusiveMinimum)」エラーが発生する).

It modifies the Zod schema for Time Entries (`src/lib/types/time_entries/schema.ts`) to ensure that the `hours` field must be a positive number.
This is done by changing `z.number()` to `z.number().positive()`.

This change should prevent the reported error by enforcing the correct type and value range for the `hours` property at the schema validation level.