### PR TITLE
Fix: Add eslint.config.js to resolve CI linting error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,17 @@
+// eslint.config.js
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    // プロジェクトのルートにある src ディレクトリ内のファイルを対象とする
+    files: ["src/**/*.{js,jsx,ts,tsx}"],
+    // ここにカスタムルールや設定を追加できます
+    // 例:
+    // rules: {
+    //   "no-unused-vars": "warn"
+    // }
+  }
+];


### PR DESCRIPTION
ESLint v9に対応するため、eslint.config.js を追加しました。これにより、CIでのリンティングエラーが解消されるはずです。