### PR TITLE
Fix: Correct exclusiveMinimum type in time_entries.ts

### DIFF
--- a/src/tools/time_entries.ts
+++ b/src/tools/time_entries.ts
@@ -97,7 +97,7 @@ export const TIME_ENTRY_CREATE_TOOL: Tool = {
         type: "number",
         description: "Number of hours spent. Can use decimals",
         minimum: 0,
-        exclusiveMinimum: true
+        exclusiveMinimum: 0
       },
       activity_id: {
         type: "number",
@@ -149,7 +149,7 @@ export const TIME_ENTRY_UPDATE_TOOL: Tool = {
         type: "number",
         description: "New number of hours. Can use decimals",
         minimum: 0,
-        exclusiveMinimum: true
+        exclusiveMinimum: 0
       },
       activity_id: {
         type: "number",


### PR DESCRIPTION
This PR fixes the type of `exclusiveMinimum` in `src/tools/time_entries.ts` as pointed out in #15.

Related to #15