### PR TITLE
Docs: Update Inspector CLI section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ For data safety, only GET operations are included in tests.
 
 Use [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector) to verify functionality.
 
+Use [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector) to verify functionality.
+
 #### GUI Mode
 
 ```bash
@@ -129,42 +131,6 @@ npx @modelcontextprotocol/inspector dist/index.js
 ```
 
 #### CLI Mode
-
-The `@modelcontextprotocol/inspector` also offers a CLI mode for more direct interaction and scripting.
-
-**Key CLI Features:**
-
-- **Connect to MCP Server:**
-  - Local build: `npx @modelcontextprotocol/inspector --cli node build/index.js`
-  - Remote URL: `npx @modelcontextprotocol/inspector --cli https://my-mcp-server.example.com`
-  - Using a config file: `npx @modelcontextprotocol/inspector --cli --config path/to/config.json --server myserver`
-- **Get Server Information:**
-  - List available tools: `--method tools/list`
-  - List available resources: `--method resources/list`
-  - List available prompts: `--method prompts/list`
-- **Execute Tools:**
-  - Call a specific tool with arguments: `--method tools/call --tool-name <tool_name> --tool-arg <key>=<value>`
-- **Environment Variables and Arguments:**
-  - Pass environment variables to the server: `-e <key>=<value>`
-  - Separate Inspector flags from server arguments with `--`.
-
-**Basic CLI Command Examples:**
-
-- Connect to a local server and list available tools:
-  ```bash
-  npx @modelcontextprotocol/inspector --cli node build/index.js --method tools/list
-  ```
-- Connect to a remote server:
-  ```bash
-  npx @modelcontextprotocol/inspector --cli https://my-mcp-server.example.com
-  ```
-- Connect using a configuration file and execute a specific tool:
-  ```bash
-  npx @modelcontextprotocol/inspector --cli --config path/to/config.json --server myserver --method tools/call --tool-name mytool --tool-arg key=value
-  ```
-
-For more detailed information, refer to the [MCP Inspector README](https://github.com/modelcontextprotocol/inspector/blob/main/README.md).
-
 #### CLI Testing Commands
 
 Here are practical examples for testing the Redmine MCP Server using CLI mode.


### PR DESCRIPTION
Inspector CLIの一般的な説明を削除し、Inspectorのドキュメントへの直接リンクを追加しました。

この変更は、`README.md` をより簡潔にし、ユーザーが必要な情報に素早くアクセスできるようにすることを目的としています。